### PR TITLE
Add missing package dependency

### DIFF
--- a/chinese-yasdcv.el
+++ b/chinese-yasdcv.el
@@ -4,6 +4,7 @@
 
 ;; Author: Feng Shu <tumashu@gmail.com>
 ;; URL: https://github.com/tumashu/chinese-yasdcv
+;; Package-Requires: ((cl-lib "0.5"))
 ;; Version: 0.0.1
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
`cl-lib` 好像从 Emacs 24 开始自带的，老版本的 Emacs 需要手动装这个包。无论如何`cl-lib`都应该算是`chinese-yasdcv`的依赖。
